### PR TITLE
Use env vars for config, add input validation and safe filenames; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ If you like you can support my work by buying me a Coffee via ko-fi.com
     chmod +x elevenbatch.sh
     ```
 
-3. Replace API_KEY="YOUR_API_KEY" with your actual ElevenLabs API key in the script.
-4. Replace API_VOICE="YOUR_API_VOICE" with the Voice you like. Use the Helper Scripts to finde the right ID
-5. Replace API_MODEL_ID="YOUR_API_MODEL_ID" with the API Model ID you like. Use the Helper Scripts to finde the right ID
+3. Set the required environment variables before running the script:
+
+   ```sh
+   export ELEVENLABS_API_KEY="your_api_key"
+   export ELEVENLABS_API_VOICE="your_voice_id"
+   export ELEVENLABS_API_MODEL_ID="your_model_id"
+   ```
 
 ## Usage MacOS / Linux
 
@@ -53,12 +57,17 @@ If you like you can support my work by buying me a Coffee via ko-fi.com
 
 1. Save the script as elevenbatch.ps1.
 2. Open PowerShell and navigate to the directory where the script is saved.
-3. Replace API_KEY="YOUR_API_KEY" with your actual ElevenLabs API key in the script.
-4. Replace API_VOICE="YOUR_API_VOICE" with the Voice you like
-5. Replace API_MODEL_ID="YOUR_API_MODEL_ID" with the API Model ID you like 
-6. Run the script
+3. Set required environment variables in PowerShell:
 
-```sh
+```powershell
+$env:ELEVENLABS_API_KEY="your_api_key"
+$env:ELEVENLABS_API_VOICE="your_voice_id"
+$env:ELEVENLABS_API_MODEL_ID="your_model_id"
+```
+
+4. Run the script:
+
+```powershell
 ./elevenbatch.ps1 <csv_file> <columns>
 ```
 
@@ -82,12 +91,22 @@ If you like you can support my work by buying me a Coffee via ko-fi.com
 
 ## Configuration
 
-Replace YOUR_API_* Values in the script with your actual ElevenLabs API key:
+Set these required environment variables before execution.
+
+Linux / macOS:
 
 ```sh
-API_KEY="YOUR_API_KEY"
-API_VOICE="YOUR_API_VOICE"
-API_MODEL_ID="YOUR_API_MODEL_ID"
+export ELEVENLABS_API_KEY="your_api_key"
+export ELEVENLABS_API_VOICE="your_voice_id"
+export ELEVENLABS_API_MODEL_ID="your_model_id"
+```
+
+Windows PowerShell:
+
+```powershell
+$env:ELEVENLABS_API_KEY="your_api_key"
+$env:ELEVENLABS_API_VOICE="your_voice_id"
+$env:ELEVENLABS_API_MODEL_ID="your_model_id"
 ```
 
 ## License

--- a/elevenbatch.ps1
+++ b/elevenbatch.ps1
@@ -1,59 +1,96 @@
-# Check if the correct number of arguments is provided
-if ($args.Count -ne 2) {
-    Write-Host "Usage: .\print_csv.ps1 <csv_file> <columns>"
-    Write-Host "Example: .\print_csv.ps1 data.csv 0,1,5,6,9,10"
-    exit
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$CsvFile,
+
+    [Parameter(Mandatory = $true, Position = 1)]
+    [string]$Columns
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $CsvFile -PathType Leaf)) {
+    Write-Error "File not found: $CsvFile"
+    exit 1
 }
 
-# Check if the file exists
-if (-not (Test-Path $args[0])) {
-    Write-Host "File not found!"
-    exit
+$API_KEY = if ($env:ELEVENLABS_API_KEY) { $env:ELEVENLABS_API_KEY } else { "YOUR_API_KEY" }
+$API_VOICE = if ($env:ELEVENLABS_API_VOICE) { $env:ELEVENLABS_API_VOICE } else { "YOUR_API_VOICE" }
+$API_MODEL_ID = if ($env:ELEVENLABS_API_MODEL_ID) { $env:ELEVENLABS_API_MODEL_ID } else { "YOUR_API_MODEL_ID" }
+
+if ($API_KEY -eq "YOUR_API_KEY" -or $API_VOICE -eq "YOUR_API_VOICE" -or $API_MODEL_ID -eq "YOUR_API_MODEL_ID") {
+    Write-Error "Please set ELEVENLABS_API_KEY, ELEVENLABS_API_VOICE and ELEVENLABS_API_MODEL_ID."
+    exit 1
 }
 
-# Get the column indices and convert them into an array
-$column_indices = $args[1] -split ','
+$columnIndices = $Columns -split ','
+foreach ($index in $columnIndices) {
+    if ($index -notmatch '^[0-9]+$') {
+        Write-Error "Invalid column index: $index"
+        exit 1
+    }
+}
 
-# Define the ElevenLabs API key
-$API_KEY = "YOUR_API_KEY"
+function Get-SafeFileName {
+    param([string]$InputValue)
 
-# Define the ElevenLabs API Voice
-# Example: Drew; 29vD33N1CtxCmqQRPOHJ | Clyde; 2EiwWnXFnvU5JabPnv8n | Paul; 5Q0t7uMcjvnagumLfvZi
-API_VOICE="YOUR_API_VOICE"
-$API_URL = "https://api.elevenlabs.io/v1/text-to-speech/"$API_VOICE
+    $safe = ($InputValue -replace '\s+', '_') -replace '[^\w-]', ''
+    if ([string]::IsNullOrWhiteSpace($safe)) {
+        return "output"
+    }
 
-# Define the ElevenLabs API Leanguage Model ID
-# Example: eleven_multilingual_v2, eleven_multilingual_v1, eleven_monolingual_v1, eleven_english_sts_v2, eleven_turbo_v2, eleven_multilingual_sts_v2
-API_MODEL_ID="YOUR_API_MODEL_ID"
+    return $safe
+}
 
-# Read the CSV file, skipping the first line
-$csv_content = Get-Content $args[0] | Select-Object -Skip 1
+function Get-UniqueFileName {
+    param([string]$BaseName)
 
-foreach ($line in $csv_content) {
+    $candidate = "$BaseName.mp3"
+    $counter = 1
+
+    while (Test-Path -LiteralPath $candidate) {
+        $candidate = "${BaseName}_$counter.mp3"
+        $counter++
+    }
+
+    return $candidate
+}
+
+$apiUrl = "https://api.elevenlabs.io/v1/text-to-speech/$API_VOICE"
+$csvContent = Get-Content -LiteralPath $CsvFile | Select-Object -Skip 1
+
+foreach ($line in $csvContent) {
     $lineArray = $line -split ';'
-    
-    foreach ($index in $column_indices) {
-        if ($index -lt $lineArray.Length) {
-            $value = $lineArray[$index].Trim('"')  # Remove double quotes
-            
-            # Ensure the filename is safe by replacing spaces with underscores and removing other problematic characters
-            $safe_value = $value -replace ' ', '_' -replace '[^\w]', ''
-            
-            # Prepare the data for the API request
+
+    foreach ($index in $columnIndices) {
+        $columnIndex = [int]$index
+        if ($columnIndex -lt $lineArray.Length) {
+            $value = $lineArray[$columnIndex].Trim('"')
+            if ([string]::IsNullOrWhiteSpace($value)) {
+                continue
+            }
+
+            $safeValue = Get-SafeFileName -InputValue $value
+            $outputFile = Get-UniqueFileName -BaseName $safeValue
+
             $data = @{
-                "voice_settings" = @{
-                    "stability" = 0.5
-                    "similarity_boost" = 0.75
-                    "style" = 0
-                    "use_speaker_boost" = $true
+                voice_settings = @{
+                    stability = 0.5
+                    similarity_boost = 0.75
+                    style = 0
+                    use_speaker_boost = $true
                 }
-                "model_id" = $API_MODEL_ID
-                "text" = $value
-            } | ConvertTo-Json
-            
-            # Send the value to the ElevenLabs API
-            Invoke-RestMethod -Method Post -Uri $API_URL -Headers @{ "Content-Type" = "application/json"; "xi-api-key" = $API_KEY } -Body $data -OutFile "${safe_value}.mp3"
-        } else {
+                model_id = $API_MODEL_ID
+                text = $value
+            } | ConvertTo-Json -Depth 4 -Compress
+
+            Invoke-RestMethod -Method Post `
+                -Uri $apiUrl `
+                -Headers @{ "Content-Type" = "application/json"; "xi-api-key" = $API_KEY } `
+                -Body $data `
+                -OutFile $outputFile
+        }
+        else {
             Write-Host "N/A"
         }
     }

--- a/elevenbatch.sh
+++ b/elevenbatch.sh
@@ -1,62 +1,125 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Check if the correct number of arguments is provided
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <csv_file> <columns>"
-    echo "Example: $0 data.csv 0,1,5,6,9,10"
+set -euo pipefail
+
+usage() {
+    cat <<USAGE
+Usage: $0 <csv_file> <columns>
+Example: $0 data.csv 0,1,5,6,9,10
+
+Configuration via environment variables:
+  ELEVENLABS_API_KEY      (required)
+  ELEVENLABS_API_VOICE    (required)
+  ELEVENLABS_API_MODEL_ID (required)
+USAGE
+}
+
+if [[ "$#" -ne 2 ]]; then
+    usage
     exit 1
 fi
 
-# Check if the file exists
-if [ ! -f "$1" ]; then
-    echo "File not found!"
+csv_file="$1"
+if [[ ! -f "$csv_file" ]]; then
+    echo "File not found: $csv_file" >&2
     exit 1
 fi
 
-# Get the column indices and convert them into an array
+if ! command -v curl >/dev/null 2>&1; then
+    echo "Missing dependency: curl" >&2
+    exit 1
+fi
+
+API_KEY="${ELEVENLABS_API_KEY:-YOUR_API_KEY}"
+API_VOICE="${ELEVENLABS_API_VOICE:-YOUR_API_VOICE}"
+API_MODEL_ID="${ELEVENLABS_API_MODEL_ID:-YOUR_API_MODEL_ID}"
+
+if [[ "$API_KEY" == "YOUR_API_KEY" || "$API_VOICE" == "YOUR_API_VOICE" || "$API_MODEL_ID" == "YOUR_API_MODEL_ID" ]]; then
+    echo "Please set ELEVENLABS_API_KEY, ELEVENLABS_API_VOICE and ELEVENLABS_API_MODEL_ID." >&2
+    exit 1
+fi
+
 IFS=',' read -r -a column_indices <<< "$2"
+for index in "${column_indices[@]}"; do
+    if [[ ! "$index" =~ ^[0-9]+$ ]]; then
+        echo "Invalid column index: $index" >&2
+        exit 1
+    fi
+done
 
-# Define the ElevenLabs API key
-API_KEY="YOUR_API_KEY"
+json_escape() {
+    local s="$1"
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    s=${s//$'\n'/\\n}
+    s=${s//$'\r'/\\r}
+    s=${s//$'\t'/\\t}
+    printf '%s' "$s"
+}
 
-# Define the ElevenLabs API Voice
-# Example: Drew; 29vD33N1CtxCmqQRPOHJ | Clyde; 2EiwWnXFnvU5JabPnv8n | Paul; 5Q0t7uMcjvnagumLfvZi
-API_VOICE="YOUR_API_VOICE"
+safe_filename() {
+    local input="$1"
+    local output
+    output=$(printf '%s' "$input" | tr '[:space:]' '_' | tr -cd '[:alnum:]_-')
+    if [[ -z "$output" ]]; then
+        output="output"
+    fi
+    printf '%s' "$output"
+}
 
-# Define the ElevenLabs API Leanguage Model ID
-API_MODEL_ID="YOUR_API_MODEL_ID"
+unique_filename() {
+    local base="$1"
+    local ext=".mp3"
+    local candidate="${base}${ext}"
+    local counter=1
 
-# Read the CSV file, skipping the first line
+    while [[ -e "$candidate" ]]; do
+        candidate="${base}_${counter}${ext}"
+        ((counter++))
+    done
+
+    printf '%s' "$candidate"
+}
+
 {
-    read
-    while IFS=';' read -r -a lineArray; do
+    read -r || true
+    while IFS=';' read -r -a line_array; do
         for index in "${column_indices[@]}"; do
-            if [ "$index" -lt "${#lineArray[@]}" ]; then
-                value="${lineArray[$index]}"
-                value="${value//\"/}"  # Remove double quotes
-                
-                # Ensure the filename is safe by replacing spaces with underscores and removing other problematic characters
-                safe_value=$(echo "$value" | tr ' ' '_' | tr -d '[:punct:]')
-                
-                # Send the value to the ElevenLabs API
-                curl --request POST \
-                     --url "https://api.elevenlabs.io/v1/text-to-speech/$API_VOICE" \
-                     --header "Content-Type: application/json" \
-                     --header "xi-api-key: $API_KEY" \
-                     --data '{
-                         "voice_settings": {
-                             "stability": 0.5,
-                             "similarity_boost": 0.75,
-                             "style": 0,
-                             "use_speaker_boost": true
-                         },
-                         "model_id": "'$API_MODEL_ID'",
-                         "text": "'"$value"'"
-                     }' \
-                     --output "${safe_value}.mp3"
+            if (( index < ${#line_array[@]} )); then
+                value="${line_array[$index]//\"/}"
+
+                if [[ -z "$value" ]]; then
+                    continue
+                fi
+
+                safe_value=$(safe_filename "$value")
+                output_file=$(unique_filename "$safe_value")
+                escaped_value=$(json_escape "$value")
+
+                payload=$(cat <<JSON
+{
+  "voice_settings": {
+    "stability": 0.5,
+    "similarity_boost": 0.75,
+    "style": 0,
+    "use_speaker_boost": true
+  },
+  "model_id": "${API_MODEL_ID}",
+  "text": "${escaped_value}"
+}
+JSON
+)
+
+                curl --fail --silent --show-error \
+                    --request POST \
+                    --url "https://api.elevenlabs.io/v1/text-to-speech/${API_VOICE}" \
+                    --header "Content-Type: application/json" \
+                    --header "xi-api-key: ${API_KEY}" \
+                    --data "$payload" \
+                    --output "$output_file"
             else
                 echo "N/A"
             fi
         done
     done
-} < "$1"
+} < "$csv_file"


### PR DESCRIPTION
### Motivation
- Replace hardcoded API credentials with environment-variable configuration to avoid embedding secrets in scripts.
- Improve robustness and portability by adding input validation, strict modes, and dependency checks for both shell and PowerShell implementations.
- Prevent filename collisions and unsafe filenames when generating MP3 outputs from CSV values.

### Description
- Update `README.md` to instruct users to set `ELEVENLABS_API_KEY`, `ELEVENLABS_API_VOICE`, and `ELEVENLABS_API_MODEL_ID` for both Linux/macOS and Windows PowerShell usage. 
- Rewrite `elevenbatch.sh` to use `set -euo pipefail`, add a `usage` helper, validate arguments and column indices, check for `curl`, and read the CSV while skipping the header; implement `safe_filename`, `unique_filename`, and `json_escape` helpers and send requests with `curl` using a compact JSON payload and robust options. 
- Rewrite `elevenbatch.ps1` to use a `param()` block, `Set-StrictMode`, `$ErrorActionPreference='Stop'`, validate file and column indices, read env vars for configuration, add `Get-SafeFileName` and `Get-UniqueFileName` helpers, build the request body with `ConvertTo-Json`, and call the ElevenLabs API via `Invoke-RestMethod` writing outputs to unique `.mp3` files. 
- Trim surrounding quotes from CSV cells and skip empty values to avoid generating empty or invalid filenames.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9383d5990832394a647c5d460a8ee)