### PR TITLE
Fix broken clickable links in README badges and text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # elevenbatch
-![Static Badge](https://img.shields.io/badge/elevenlabs-.io-blue?style=flat&link=https%3A%2F%2Felevenlabs.io%2F%3Ffrom%3Dpartnerkhan1060)
-![Static Badge](https://img.shields.io/badge/Buy_Me_a_Coffee_at-ko--fi.com-blue?style=flat&logo=kofi&link=https%3A%2F%2Fko-fi.com%2Fgrossstadtmann)
+[![ElevenLabs Partner](https://img.shields.io/badge/elevenlabs-.io-blue?style=flat)](https://elevenlabs.io/?from=partnerkhan1060)
+[![Buy Me a Coffee at ko-fi.com](https://img.shields.io/badge/Buy_Me_a_Coffee_at-ko--fi.com-blue?style=flat&logo=kofi)](https://ko-fi.com/grossstadtmann)
 
 elevenbatch is a shell and powershell script collection for batch processing text-to-speech conversions using the ElevenLabs Text-to-Speech API. The script reads a CSV file, extracts specified columns, and converts each value into an MP3 file using the API.
 
-If you like you can support my work by buying me a Coffee via ko-fi.com
+If you like, you can support my work by buying me a coffee via [ko-fi.com](https://ko-fi.com/grossstadtmann).
 
 ## Features
 
@@ -19,7 +19,7 @@ If you like you can support my work by buying me a Coffee via ko-fi.com
 
 - Bash shell
 - `curl` command-line tool
-- ElevenLabs Subscription to create an API key -> support me via that [Link](elevenlabs.io/?from=partnerkhan1060)
+- ElevenLabs Subscription to create an API key -> support me via that [Link](https://elevenlabs.io/?from=partnerkhan1060)
 - ElevenLabs Voice ID
 - ElevenLabs Modle ID
 


### PR DESCRIPTION
### Motivation
- GitHub was treating some README link targets as relative (missing `https://`) and the shield image `link=` parameters were not reliably producing clickable badges, so links needed to be made explicit to ensure they work on GitHub.

### Description
- Replaced the top badge images with markdown-linked badge images for ElevenLabs and Ko-fi, converted the Ko-fi mention in the body to an explicit `[ko-fi.com](https://ko-fi.com/grossstadtmann)` link, and fixed the ElevenLabs prerequisite link by adding the `https://` scheme.

### Testing
- Ran `rg -n "\]\((elevenlabs\.io|ko-fi\.com)" README.md` to check for scheme-less links and inspected `git diff -- README.md` and `git status --short`, and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93d6c0d9483238a999e592ca19475)